### PR TITLE
Fix UsageTracker Loading State on Navigation

### DIFF
--- a/frontend/src/components/AppLayout/Sider/UsageTracker.tsx
+++ b/frontend/src/components/AppLayout/Sider/UsageTracker.tsx
@@ -13,7 +13,7 @@ export const UsageTracker = () => {
         fetchUsage()
     }, [fetchUsage])
 
-    if (loading) {
+    if (loading && !usage) {
         return (
             <div className="p-3 border rounded-lg bg-muted/50">
                 <div className="flex items-center justify-center py-4">


### PR DESCRIPTION
## Problem

The UsageTracker component was showing a loading spinner every time the user navigated between pages, causing the sidebar to flicker.

## For testing and fixing this issue

To test and fix the problem, I created a `fetchUsageMock()` function that mimics the behavior of the actual API call.
Since I couldn’t find a way to smoothly run usage endpoint locally, I didn’t include this mock in the PR — but everything should work seamlessly in production.

> Note: I know this might not be the kind of PR the team is looking for, since it’s more related to the self-deployed setup rather than the main product. Still, I found this issue and figured it could be a small contribution.