### PR TITLE
added  user name and email on Sider #109

### DIFF
--- a/frontend/src/components/AppLayout/Sider/Sider.tsx
+++ b/frontend/src/components/AppLayout/Sider/Sider.tsx
@@ -2,6 +2,17 @@ import { ProjectSwitcher } from '@/components/AppLayout/Sider/ProjectSwitcher'
 import { TalkToFounderModal } from '@/components/AppLayout/Sider/TalkToFounderModal'
 import { UsageTracker } from '@/components/AppLayout/Sider/UsageTracker'
 import { useTheme } from '@/components/ThemeProvider'
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
 import {
     Sidebar,
     SidebarContent,
@@ -12,12 +23,14 @@ import {
     SidebarMenu,
     SidebarMenuButton,
     SidebarMenuItem,
+    useSidebar,
 } from '@/components/ui/sidebar'
 import { isSelfHostedDeploy } from '@/config'
 import { useAuthStore, UserDetails } from '@/stores/authStore'
 import { useProjectStore } from '@/stores/projectStore'
 import {
     BookOpen,
+    ChevronsUpDown,
     CreditCard,
     Files,
     FlaskConical,
@@ -52,6 +65,18 @@ export const Sider = () => {
     const { theme, toggleTheme } = useTheme()
     const currentProject = useProjectStore((state) => state.currentProject)
     const [talkToFounderModalOpen, setTalkToFounderModalOpen] = useState(false)
+
+    const { isMobile } = useSidebar()
+
+    const getUserName = () => {
+        const name = user?.name?.trim()
+        return name || 'User'
+    }
+
+    const getUserEmail = () => {
+        const email = user?.email?.trim()
+        return email || 'user@example.com'
+    }
 
     const mainMenuItems: Record<string, MenuItem[]> = {
         Project: [
@@ -245,26 +270,48 @@ export const Sider = () => {
                                 ))}
 
                             {/* Icon buttons row */}
-                            <div className="flex justify-center gap-2 px-2 py-1 mt-1">
-                                <SidebarMenuItem className="flex-col">
-                                    <p className="text-xs truncate">{user?.name}</p>
-                                    <p className="text-xs truncate">{user?.email}</p>
-                                </SidebarMenuItem>
-                                <SidebarMenuButton
-                                    onClick={toggleTheme}
-                                    className="h-8 w-8 p-0 cursor-pointer flex items-center justify-center"
-                                    title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-                                >
-                                    {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-                                </SidebarMenuButton>
-                                <SidebarMenuButton
-                                    onClick={logout}
-                                    className="h-8 w-8 p-0 cursor-pointer flex items-center justify-center"
-                                    title="Logout"
-                                >
-                                    <LogOut className="h-4 w-4" />
-                                </SidebarMenuButton>
-                            </div>
+                            <SidebarMenuItem>
+                                <DropdownMenu modal={false}>
+                                    <DropdownMenuTrigger className="flex items-center gap-2 justify-between w-full my-2 px-2 hover:bg-sidebar-accent rounded-md py-2">
+                                        <div className="grid flex-1 text-left text-sm leading-tight">
+                                            <span className="truncate font-medium">{getUserName()}</span>
+                                            <span className="truncate text-xs">{getUserEmail()}</span>
+                                        </div>
+                                        <ChevronsUpDown className="ml-auto size-4" />
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                        className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                                        side={isMobile ? 'bottom' : 'right'}
+                                        align="end"
+                                        sideOffset={4}
+                                    >
+                                        <DropdownMenuLabel className="p-0 font-normal">
+                                            <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                                                <div className="grid flex-1 text-left text-sm leading-tight">
+                                                    <span className="truncate font-medium">{getUserName()}</span>
+                                                    <span className="truncate text-xs">{getUserEmail()}</span>
+                                                </div>
+                                            </div>
+                                        </DropdownMenuLabel>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuGroup>
+                                            <DropdownMenuItem onSelect={toggleTheme} className="gap-x-1">
+                                                {theme === 'dark' ? (
+                                                    <Sun className="size-4" />
+                                                ) : (
+                                                    <Moon className="size-4" />
+                                                )}
+                                                Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
+                                            </DropdownMenuItem>
+                                        </DropdownMenuGroup>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem onSelect={logout} className="gap-x-1">
+                                            <LogOut className="size-4" />
+                                            Log out
+                                        </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </SidebarMenuItem>
                         </SidebarMenu>
                     </SidebarGroupContent>
                 </SidebarGroup>


### PR DESCRIPTION
Displaying username and email on App Sider 

Previous: 
<img width="532" height="360" alt="image" src="https://github.com/user-attachments/assets/f7b107ab-75c7-4fbb-8ab7-e2c57e811b65" />

Now: 
<img width="424" height="266" alt="image" src="https://github.com/user-attachments/assets/4b342e3b-9daf-463b-92c5-0d54608090de" />


note: 
using truncate to shorten name or email by cutting off the end if it's too large. 


close:  #109