### PR TITLE
fix: batch memo status polling to avoid rate limits (Closes #129)

### DIFF
--- a/backend/src/__tests__/memo.test.ts
+++ b/backend/src/__tests__/memo.test.ts
@@ -1330,6 +1330,278 @@ describe('Memo API Tests', () => {
         })
     })
 
+    describe('POST /api/memos/statuses - Batch Memo Status', () => {
+        it('should return statuses for multiple memos in a single request', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const memo1 = await createTestMemo(orm, project, { title: 'Memo 1', content: 'Content 1' })
+            const memo2 = await createTestMemo(orm, project, { title: 'Memo 2', content: 'Content 2' })
+            const memo3 = await createTestMemo(orm, project, { title: 'Memo 3', content: 'Content 3' })
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [memo1.uuid, memo2.uuid, memo3.uuid],
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.body.statuses).toHaveLength(3)
+            expect(response.body.not_found).toEqual([])
+            const uuids = response.body.statuses.map((s: { memo_uuid: string }) => s.memo_uuid).sort()
+            expect(uuids).toEqual([memo1.uuid, memo2.uuid, memo3.uuid].sort())
+            response.body.statuses.forEach((s: { status: string }) => {
+                expect(s.status).toBe('processing')
+            })
+        })
+
+        it('should normalize received status to processing in batch', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const memo = await createTestMemo(orm, project, { title: 'Memo', content: 'Content' })
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [memo.uuid],
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.body.statuses[0].status).toBe('processing')
+        })
+
+        it('should return terminal statuses with timestamps and error reason', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const processedMemo = await createTestMemo(orm, project, { title: 'Processed', content: 'C1' })
+            const errorMemo = await createTestMemo(orm, project, { title: 'Error', content: 'C2' })
+
+            const em = orm.em.fork()
+            const processed = await em.findOne(Memo, { uuid: processedMemo.uuid })
+            if (processed) {
+                processed.processing_status = 'processed'
+                processed.processing_started_at = new Date()
+                processed.processing_completed_at = new Date()
+                await em.persistAndFlush(processed)
+            }
+            const errored = await em.findOne(Memo, { uuid: errorMemo.uuid })
+            if (errored) {
+                errored.processing_status = 'error'
+                errored.processing_started_at = new Date()
+                errored.processing_completed_at = new Date()
+                errored.processing_error = 'Embedding failed'
+                await em.persistAndFlush(errored)
+            }
+
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [processedMemo.uuid, errorMemo.uuid],
+                })
+
+            expect(response.status).toBe(200)
+            const byUuid = Object.fromEntries(
+                response.body.statuses.map((s: { memo_uuid: string }) => [s.memo_uuid, s])
+            )
+            expect(byUuid[processedMemo.uuid].status).toBe('processed')
+            expect(byUuid[processedMemo.uuid].processing_completed_at).toBeDefined()
+            expect(byUuid[processedMemo.uuid].error_reason).toBeNull()
+            expect(byUuid[errorMemo.uuid].status).toBe('error')
+            expect(byUuid[errorMemo.uuid].error_reason).toBe('Embedding failed')
+        })
+
+        it('should support id_type reference_id', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            await createTestMemo(orm, project, {
+                title: 'Memo 1',
+                content: 'Content 1',
+                client_reference_id: 'ref-1',
+            })
+            await createTestMemo(orm, project, {
+                title: 'Memo 2',
+                content: 'Content 2',
+                client_reference_id: 'ref-2',
+            })
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: ['ref-1', 'ref-2'],
+                    id_type: 'reference_id',
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.body.statuses).toHaveLength(2)
+            const refs = response.body.statuses
+                .map((s: { client_reference_id: string }) => s.client_reference_id)
+                .sort()
+            expect(refs).toEqual(['ref-1', 'ref-2'])
+        })
+
+        it('should report missing ids in not_found', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const memo = await createTestMemo(orm, project, { title: 'Real', content: 'Content' })
+            const token = generateAccessToken('test@example.com')
+
+            const fakeUuid = '00000000-0000-0000-0000-000000000000'
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [memo.uuid, fakeUuid],
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.body.statuses).toHaveLength(1)
+            expect(response.body.statuses[0].memo_uuid).toBe(memo.uuid)
+            expect(response.body.not_found).toEqual([fakeUuid])
+        })
+
+        it('should reject an empty memo_ids array', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [],
+                })
+
+            expect(response.status).toBe(400)
+            expect(response.body.error).toContain('memo_ids')
+        })
+
+        it('should reject more than 100 memo_ids', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const token = generateAccessToken('test@example.com')
+
+            const tooMany = Array.from({ length: 101 }, (_, i) => `id-${i}`)
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: tooMany,
+                })
+
+            expect(response.status).toBe(400)
+            expect(response.body.error).toContain('100')
+        })
+
+        it('should reject missing memo_ids field', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                })
+
+            expect(response.status).toBe(400)
+        })
+
+        it('should set cache-control to no-cache', async () => {
+            const user = await createTestUser(orm, 'test@example.com', 'password123')
+            const org = await createTestOrganization(orm, 'Test Org', user)
+            await createTestOrganizationMembership(orm, user, org)
+            const project = await createTestProject(orm, 'Test Project', org, user)
+            const memo = await createTestMemo(orm, project, { title: 'Memo', content: 'Content' })
+            const token = generateAccessToken('test@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${token}`])
+                .send({
+                    project_id: project.uuid,
+                    memo_ids: [memo.uuid],
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.headers['cache-control']).toBe('no-cache')
+        })
+
+        it('should not leak memos from another project (IDOR check)', async () => {
+            const user1 = await createTestUser(orm, 'user1@example.com', 'password123')
+            const user2 = await createTestUser(orm, 'user2@example.com', 'password123')
+
+            const org1 = await createTestOrganization(orm, 'Org 1', user1)
+            const org2 = await createTestOrganization(orm, 'Org 2', user2)
+
+            await createTestOrganizationMembership(orm, user1, org1)
+            await createTestOrganizationMembership(orm, user2, org2)
+
+            const project1 = await createTestProject(orm, 'Project 1', org1, user1)
+            const project2 = await createTestProject(orm, 'Project 2', org2, user2)
+
+            const memo1 = await createTestMemo(orm, project1, { title: 'User1 Memo', content: 'C1' })
+            const memo2 = await createTestMemo(orm, project2, { title: 'User2 Memo', content: 'C2' })
+
+            const user1Token = generateAccessToken('user1@example.com')
+
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .set('Cookie', [`accessToken=${user1Token}`])
+                .send({
+                    project_id: project1.uuid,
+                    memo_ids: [memo1.uuid, memo2.uuid],
+                })
+
+            expect(response.status).toBe(200)
+            expect(response.body.statuses).toHaveLength(1)
+            expect(response.body.statuses[0].memo_uuid).toBe(memo1.uuid)
+            expect(response.body.not_found).toEqual([memo2.uuid])
+        })
+
+        it('should require authentication', async () => {
+            const response = await request(app)
+                .post('/api/memos/statuses')
+                .send({
+                    project_id: '00000000-0000-0000-0000-000000000000',
+                    memo_ids: ['any-id'],
+                })
+
+            expect(response.status).toBe(403)
+        })
+    })
+
     describe('Usage Tracking for Memo Creation', () => {
         it('should count memo with < 3000 chars as 1 write towards usage record', async () => {
             const user = await createTestUser(orm, 'test@example.com', 'password123')

--- a/backend/src/api/memo.ts
+++ b/backend/src/api/memo.ts
@@ -78,6 +78,14 @@ const UpdateMemoRequest = z.object({
     scopes: z.record(z.string(), z.string()).optional(),
 })
 
+const BatchMemoStatusRequest = z.object({
+    memo_ids: z
+        .array(z.string().min(1, 'memo_ids entries cannot be empty'))
+        .min(1, 'memo_ids must contain at least one id')
+        .max(100, 'memo_ids cannot exceed 100 ids per request'),
+    id_type: z.enum(['memo_uuid', 'reference_id']).optional().default('memo_uuid'),
+})
+
 const validateMemoOperationRequestMiddleware = () => {
     return async (req: Request, res: Response, next: NextFunction) => {
         const project = req.context?.requestUser?.project
@@ -511,6 +519,56 @@ export const getMemoStatus = async (req: Request, res: Response) => {
     })
 }
 
+export const getBatchMemoStatuses = async (req: Request, res: Response) => {
+    const project = req.context?.requestUser?.project as Project
+
+    const validatedData = BatchMemoStatusRequest.safeParse(req.body)
+    if (!validatedData.success) {
+        const errorMessages = validatedData.error.errors.map((err) => err.message)
+        return res.status(400).json({ error: errorMessages.join(', ') })
+    }
+
+    const { memo_ids, id_type } = validatedData.data
+    const lookupField = id_type === 'memo_uuid' ? 'uuid' : 'client_reference_id'
+
+    const memos = await DI.memos.find(
+        { [lookupField]: { $in: memo_ids }, project },
+        {
+            fields: [
+                'uuid',
+                'client_reference_id',
+                'processing_status',
+                'processing_started_at',
+                'processing_completed_at',
+                'processing_error',
+            ],
+        }
+    )
+
+    const statuses = memos.map((memo) => ({
+        memo_uuid: memo.uuid,
+        client_reference_id: memo.client_reference_id || null,
+        status: memo.processing_status === 'received' ? 'processing' : memo.processing_status,
+        processing_started_at: memo.processing_started_at || null,
+        processing_completed_at: memo.processing_completed_at || null,
+        error_reason: memo.processing_error || null,
+    }))
+
+    const foundIds = new Set(
+        memos
+            .map((memo) => (id_type === 'memo_uuid' ? memo.uuid : memo.client_reference_id))
+            .filter(Boolean) as string[]
+    )
+    const notFound = memo_ids.filter((id) => !foundIds.has(id))
+
+    res.set('Cache-Control', 'no-cache')
+
+    return res.status(200).json({
+        statuses,
+        not_found: notFound,
+    })
+}
+
 export const memoRouter = express.Router({ mergeParams: true })
 memoRouter.use(requireProjectAccess())
 memoRouter.get('/', listMemos)
@@ -571,6 +629,7 @@ memoRouter.post('/', upload.single('file'), handleMulterError, (req: Request, re
         return await createPlaintextMemo(req, res)
     })
 )
+memoRouter.post('/statuses', getBatchMemoStatuses)
 memoRouter.get('/:id/status', [validateMemoOperationRequestMiddleware()], getMemoStatus)
 memoRouter.get('/:id', [validateMemoOperationRequestMiddleware()], getMemo)
 memoRouter.patch('/:id', [validateMemoOperationRequestMiddleware()], updateMemo)

--- a/frontend/src/stores/memoStore.ts
+++ b/frontend/src/stores/memoStore.ts
@@ -4,6 +4,11 @@ import { toast } from 'sonner'
 import type { Memo, DetailedMemo, SearchResult, SearchMethod } from '@/lib/types'
 import { useProjectStore } from './projectStore'
 
+const INITIAL_POLL_MS = 3000
+const MAX_POLL_MS = 30000
+const BACKOFF_MULTIPLIER = 1.5
+const MAX_BATCH_SIZE = 100
+
 interface PaginatedResponse<T> {
     count: number
     next: string | null
@@ -52,6 +57,11 @@ interface MemoStatusResponse {
     error_reason: string | null
 }
 
+interface BatchMemoStatusesResponse {
+    statuses: MemoStatusResponse[]
+    not_found: string[]
+}
+
 interface MemoState {
     memos: Memo[]
     loading: boolean
@@ -62,7 +72,9 @@ interface MemoState {
     totalCount: number
     currentPage: number
     pageSize: number
-    pollingIntervals: Map<string, NodeJS.Timeout>
+    pollingTimeoutId: ReturnType<typeof setTimeout> | null
+    pollingBackoffMs: number
+    pollingActive: boolean
     fetchMemos: (page?: number, pageSize?: number) => Promise<void>
     searchMemos: (query: string, method: SearchMethod) => Promise<void>
     createMemo: (payload: CreateMemoPayload) => Promise<boolean>
@@ -71,9 +83,10 @@ interface MemoState {
     getMemoDetails: (memoUuid: string) => Promise<DetailedMemo | null>
     updateMemo: (memoUuid: string, payload: UpdateMemoPayload) => Promise<boolean>
     getMemoStatus: (memoUuid: string) => Promise<MemoStatusResponse | null>
+    getBatchMemoStatuses: (memoUuids: string[]) => Promise<MemoStatusResponse[]>
     updateMemoStatus: (memoUuid: string, status: 'processing' | 'processed' | 'error') => void
+    refreshProcessedMemo: (memoUuid: string) => Promise<void>
     startPollingProcessingMemos: () => void
-    stopPollingMemo: (memoUuid: string) => void
     stopAllPolling: () => void
     setSearchQuery: (query: string) => void
     clearSearch: () => void
@@ -89,7 +102,9 @@ export const useMemoStore = create<MemoState>((set, get) => ({
     totalCount: 0,
     currentPage: 1,
     pageSize: 20,
-    pollingIntervals: new Map(),
+    pollingTimeoutId: null,
+    pollingBackoffMs: INITIAL_POLL_MS,
+    pollingActive: false,
 
     fetchMemos: async (page = 1, pageSize = 50) => {
         set({ loading: true, error: null, isSearchMode: false })
@@ -378,35 +393,67 @@ export const useMemoStore = create<MemoState>((set, get) => ({
             }
 
             if (response.data.status === 'processed') {
-                const memoDetails = await get().getMemoDetails(memoUuid)
-                if (memoDetails) {
-                    const currentMemos = get().memos
-                    const memoIndex = currentMemos.findIndex((m) => m.uuid === memoUuid)
-
-                    const updatedMemo: Memo = {
-                        uuid: memoDetails.uuid,
-                        created_at: memoDetails.created_at,
-                        updated_at: memoDetails.updated_at,
-                        title: memoDetails.title,
-                        summary: memoDetails.summary || '',
-                        metadata: memoDetails.metadata,
-                        client_reference_id: memoDetails.client_reference_id,
-                        processing_status: memoDetails.processing_status,
-                    }
-
-                    if (memoIndex !== -1) {
-                        const updatedMemos = [...currentMemos]
-                        updatedMemos[memoIndex] = updatedMemo
-                        set({ memos: updatedMemos })
-                    } else {
-                        set({ memos: [...currentMemos, updatedMemo] })
-                    }
-                }
+                await get().refreshProcessedMemo(memoUuid)
             }
 
             return response.data
         } catch {
             return null
+        }
+    },
+
+    getBatchMemoStatuses: async (memoUuids: string[]) => {
+        const currentProject = useProjectStore.getState().currentProject
+        if (!currentProject) {
+            throw new Error('No project selected')
+        }
+
+        if (memoUuids.length === 0) {
+            return []
+        }
+
+        try {
+            const response = await api.post<BatchMemoStatusesResponse>('/v1/memo/statuses', {
+                project_id: currentProject.uuid,
+                memo_ids: memoUuids.slice(0, MAX_BATCH_SIZE),
+            })
+
+            if (response.error || !response.data) {
+                return []
+            }
+
+            return response.data.statuses
+        } catch {
+            return []
+        }
+    },
+
+    refreshProcessedMemo: async (memoUuid: string) => {
+        const memoDetails = await get().getMemoDetails(memoUuid)
+        if (!memoDetails) {
+            return
+        }
+
+        const currentMemos = get().memos
+        const memoIndex = currentMemos.findIndex((m) => m.uuid === memoUuid)
+
+        const updatedMemo: Memo = {
+            uuid: memoDetails.uuid,
+            created_at: memoDetails.created_at,
+            updated_at: memoDetails.updated_at,
+            title: memoDetails.title,
+            summary: memoDetails.summary || '',
+            metadata: memoDetails.metadata,
+            client_reference_id: memoDetails.client_reference_id,
+            processing_status: memoDetails.processing_status,
+        }
+
+        if (memoIndex !== -1) {
+            const updatedMemos = [...currentMemos]
+            updatedMemos[memoIndex] = updatedMemo
+            set({ memos: updatedMemos })
+        } else {
+            set({ memos: [...currentMemos, updatedMemo] })
         }
     },
 
@@ -419,48 +466,64 @@ export const useMemoStore = create<MemoState>((set, get) => ({
     },
 
     startPollingProcessingMemos: () => {
-        const currentMemos = get().memos
-        const processingMemos = currentMemos.filter((memo) => memo.processing_status === 'processing')
+        if (get().pollingActive) {
+            return
+        }
 
-        processingMemos.forEach((memo) => {
-            // Don't start polling if already polling this memo
-            if (get().pollingIntervals.has(memo.uuid)) {
+        set({ pollingActive: true, pollingBackoffMs: INITIAL_POLL_MS })
+
+        const tick = async () => {
+            if (!get().pollingActive) {
                 return
             }
 
-            const pollMemo = async () => {
-                const statusResponse = await get().getMemoStatus(memo.uuid)
-                if (statusResponse && statusResponse.status !== 'processing') {
-                    // Status changed, update the memo
-                    get().updateMemoStatus(memo.uuid, statusResponse.status)
-                    // Stop polling this memo
-                    get().stopPollingMemo(memo.uuid)
+            const processingUuids = get()
+                .memos.filter((memo) => memo.processing_status === 'processing')
+                .map((memo) => memo.uuid)
+
+            if (processingUuids.length === 0) {
+                get().stopAllPolling()
+                return
+            }
+
+            const statuses = await get().getBatchMemoStatuses(processingUuids)
+
+            let anyChanged = false
+            for (const status of statuses) {
+                if (status.status === 'processing') {
+                    continue
+                }
+                anyChanged = true
+                get().updateMemoStatus(status.memo_uuid, status.status)
+                if (status.status === 'processed') {
+                    await get().refreshProcessedMemo(status.memo_uuid)
                 }
             }
 
-            // Poll immediately once
-            pollMemo()
+            if (!get().pollingActive) {
+                return
+            }
 
-            // Then poll every 3 seconds
-            const intervalId = setInterval(pollMemo, 3000)
-            get().pollingIntervals.set(memo.uuid, intervalId)
-        })
-    },
+            const nextBackoff = anyChanged
+                ? INITIAL_POLL_MS
+                : Math.min(MAX_POLL_MS, Math.round(get().pollingBackoffMs * BACKOFF_MULTIPLIER))
 
-    stopPollingMemo: (memoUuid: string) => {
-        const intervalId = get().pollingIntervals.get(memoUuid)
-        if (intervalId) {
-            clearInterval(intervalId)
-            const newIntervals = new Map(get().pollingIntervals)
-            newIntervals.delete(memoUuid)
-            set({ pollingIntervals: newIntervals })
+            const timeoutId = setTimeout(tick, nextBackoff)
+            set({ pollingBackoffMs: nextBackoff, pollingTimeoutId: timeoutId })
         }
+
+        tick()
     },
 
     stopAllPolling: () => {
-        get().pollingIntervals.forEach((intervalId) => {
-            clearInterval(intervalId)
+        const timeoutId = get().pollingTimeoutId
+        if (timeoutId) {
+            clearTimeout(timeoutId)
+        }
+        set({
+            pollingActive: false,
+            pollingTimeoutId: null,
+            pollingBackoffMs: INITIAL_POLL_MS,
         })
-        set({ pollingIntervals: new Map() })
     },
 }))


### PR DESCRIPTION
  ## Problem                                                                                                                                                     
                                                                                          
  The memos page polls `GET /v1/memo/:id/status` per memo every 3s, which hits                                                                                   
  the backend's 1000 req/min rate limiter when many memos are uploaded.
                                                                                                                                                                 
  Closes #129                                                                             
                                                                                                                                                                 
  ## Fix                                                                                                                                                         
                                               
  - New backend endpoint `POST /v1/memo/statuses` accepting up to 100 memo IDs,                                                                                  
    scoped by project, mirroring the single-status handler's response shape.              
  - Rewrote `memoStore.ts` polling to use one batched request per tick with                                                                                      
    exponential backoff (3s → 30s, ×1.5; resets on state change). 